### PR TITLE
Add newline, tab, and optional repetition to whitespace

### DIFF
--- a/gbnf/src/lib.rs
+++ b/gbnf/src/lib.rs
@@ -1024,9 +1024,13 @@ impl Grammar {
                 items: vec![ProductionItem::CharacterSet(
                     CharacterSet {
                         is_complement: false,
-                        items: vec![CharacterSetItem::Character(' ')],
+                        items: vec![
+                            CharacterSetItem::Character(' '),
+                            CharacterSetItem::Tab,
+                            CharacterSetItem::NewLine,
+                        ],
                     },
-                    RepetitionType::One,
+                    RepetitionType::ZeroOrMore,
                 )],
             },
         }));
@@ -1068,7 +1072,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         );
     }
@@ -1103,7 +1107,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         );
     }
@@ -1138,7 +1142,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         );
     }
@@ -1187,7 +1191,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         )
     }
@@ -1250,7 +1254,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         )
     }
@@ -1304,7 +1308,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#,
         )
     }
@@ -1340,7 +1344,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         )
     }
@@ -1372,7 +1376,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         )
     }
@@ -1404,7 +1408,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         )
     }
@@ -1436,7 +1440,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         )
     }
@@ -1472,7 +1476,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         )
     }
@@ -1563,7 +1567,7 @@ null ::= "null" ws
 boolean ::= "true" | "false" ws
 string ::= "\"" ([^"\\] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\"" ws
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-ws ::= [ ]
+ws ::= [ \t\n]*
 "#
         )
     }


### PR DESCRIPTION
When generating GBNF grammars from json schema, using `Grammar::from_json_schema`, the current implementation will emit a grammar with a whitespace definition like this: `ws ::= [ ]` (a mandatory single space).

This makes for some pretty awkwardly-formatted json:

```json
{ "name" : "get_current_temperature"  , "arguments" : { "location" : "Copenhagen"  } }
```

I think it would be much better to let the whitespace be optional, to allow it to include newlines and tab characters. This is what this PR does. Whitespace now looks like this: `ws ::= [ \t\n]*`

I adjusted the tests to reflect this change, and it all seems to work fine.

The [example json grammar](https://github.com/ggml-org/llama.cpp/blob/79c137f77677b3c8ee3c60a7da033721b938399a/grammars/json.gbnf) in the llama.cpp repo does something very similar. However, they only allow repeated newlines and tabs, at a maximum of 20.

I guess the case for constraining output length is to prevent it from generating whitespace foever? But since there are already unconstrained lengths on most of the primitive values used by this crate, I figured it doesn't really hurt to add another one.