### PR TITLE
Replace 'value' with 'const' keyword for spec compliance

### DIFF
--- a/gbnf/src/lib.rs
+++ b/gbnf/src/lib.rs
@@ -342,7 +342,7 @@ fn parse_json_schema_to_grammar(
                         None => {
                             // if its not enum , probably constant value
 
-                            match value.get("value") {
+                            match value.get("const") {
                                 Some(v) => {
                                     if v.is_string() {
                                         let v_as_string = match v.as_str() {
@@ -1350,7 +1350,7 @@ ws ::= [ ]
         let schema = r#"
         {
          "$schema": "https://json-schema.org/draft/2019-09/schema",
-         "value": "red"
+         "const": "red"
      }
                  "#;
         let g = Grammar::from_json_schema(schema).unwrap();
@@ -1382,7 +1382,7 @@ ws ::= [ ]
         let schema = r#"
         {
          "$schema": "https://json-schema.org/draft/2019-09/schema",
-         "value": 42
+         "const": 42
      }
                  "#;
         let g = Grammar::from_json_schema(schema).unwrap();
@@ -1414,7 +1414,7 @@ ws ::= [ ]
         let schema = r#"
         {
          "$schema": "https://json-schema.org/draft/2019-09/schema",
-         "value": true
+         "const": true
      }
                  "#;
         let g = Grammar::from_json_schema(schema).unwrap();
@@ -1506,7 +1506,7 @@ ws ::= [ ]
                             "type": "object",
                             "properties": {
                                 "type": {
-                                    "value": "hugging_face"
+                                    "const": "hugging_face"
                                 },
                                 "name": {
                                     "type": "string"
@@ -1517,7 +1517,7 @@ ws ::= [ ]
                             "type": "object",
                             "properties": {
                                 "type": {
-                                    "value": "openai"
+                                    "const": "openai"
                                 }
                             }
                         }


### PR DESCRIPTION
This confused me for a bit. I assume it's just a mistake in this library? Please let me know if there's something I'm unaware of or just mistaken about :innocent: 

It looks like the current implementation on `main` will accept schemae that look like this:

```json
{
         "$schema": "https://json-schema.org/draft/2019-09/schema",
         "value": "red"
}
```

Which should generate grammars like this:

```bnf
root ::= "red"
```

...but as far as I can tell, `"value"` isn't a valid json schema keyword, and I don't think it ever has been?

However, `"const"` *is* a valid json schema keyword, also in 2019-09 ([see the spec here](https://json-schema.org/draft/2019-09/json-schema-validation#rfc.section.6.1.3)), which is the version that the schemae in the unit tests point to.

The fix is pretty simple: I just replaced the string "value" with the string "const" in the relevant places.

This is a breaking change, since schemae that previously expected a "value" keyword to behave like the "const" keyword will no longer work.

It smells a tiny bit like vibecoding in here :wink: 