### PR TITLE
fix: handling underscores in nonterminals

### DIFF
--- a/gbnf/src/lib.rs
+++ b/gbnf/src/lib.rs
@@ -571,7 +571,7 @@ fn parse_json_schema_to_grammar(
         let mut is_first = true;
         for (key, value) in properties.as_object().unwrap() {
             let new_c =
-                parse_json_schema_to_grammar(value, g, format!("symbol{}-{}-value", c, key), c)?;
+                parse_json_schema_to_grammar(value, g, format!("symbol{}-{}-value", c, key.replace("_", "-")), c)?;
             if !is_first {
                 prop_rules.push(ProductionItem::Terminal(
                     TerminalSymbol {
@@ -614,7 +614,7 @@ fn parse_json_schema_to_grammar(
             ));
             prop_rules.push(ProductionItem::NonTerminal(
                 NonTerminalSymbol {
-                    name: format!("symbol{}-{}-value", c, key),
+                    name: format!("symbol{}-{}-value", c, key.replace("_", "-")),
                 },
                 RepetitionType::One,
             ));


### PR DESCRIPTION
The parse_json_to_grammar can not currently handle underscores in names. This is due to the way it mangles the value type for a key. 

Take this example:
```json
{
  "type": "object",
  "properties": {
    "text_with_underscores": {
      "type": "string"
    }
  },
  "required": [
    "text_with_underscores"
  ]
}
```
currently this will generate a schema looking like this:
```
symbol2-name-value ::= "\"underscores_bad\""
symbol4-text_with_underscores-value ::= string ws
symbol3-arguments-value ::= "{" ws "\"text_with_underscores\"" ws ":" ws symbol4-text_with_underscores-value "}" ws
symbol-1-oneof-0 ::= "{" ws "\"name\"" ws ":" ws symbol2-name-value "," ws "\"arguments\"" ws ":" ws symbol3-arguments-value "}" ws
root ::= symbol-1-oneof-0
```

however this will cause a parse error with llama.cpp due the gbnf spec requiring that nonterminals does not include an underscore. 


---
## Solution

The solution is to take the keys and replace the underscores with dashes. Due to how the LHS keys are currently generated they are already unique and cannot collide with other similar named keys (ie. `"text-with-underscores"` would not collide with `"text_with_underscores"`). 




