### PR TITLE
Support for const arrays

### DIFF
--- a/gbnf/src/json.rs
+++ b/gbnf/src/json.rs
@@ -605,8 +605,12 @@ fn create_object_grammar_items(
         let mut prop_rules = vec![];
         let mut is_first = true;
         for (key, value) in properties.as_object().unwrap() {
-            let new_c =
-                parse_json_schema_to_grammar(value, g, format!("symbol{}-{}-value", c, key.replace("_", "-")), *c)?;
+            let new_c = parse_json_schema_to_grammar(
+                value,
+                g,
+                format!("symbol{}-{}-value", c, key.replace("_", "-")),
+                *c,
+            )?;
             if !is_first {
                 prop_rules.push(ProductionItem::Terminal(
                     TerminalSymbol {


### PR DESCRIPTION
This is a small feature update that was born out of the needs of my project [paperless-field-extractor](https://github.com/ju6ge/paperless-field-extractor).

Basically this just allows using something like this as a schema:

``` json
{ "const": [ "Value1", "Value2" ] }
```

Which would result in forcing models using the generated grammar to output an array with fixed entries:

``` json
[ "Value1", "Value2"]
```

The idea behind this is that when using structed output of a model letting it print the allowed values for an enum before letting it print a value from that enum results in better output. This keeps prompt engineering minimal by better guiding the model output through grammar constraints.

Kind regards,
ju6ge