### PR TITLE
Added comma seperators to array rule

### DIFF
--- a/gbnf/src/json.rs
+++ b/gbnf/src/json.rs
@@ -1436,7 +1436,7 @@ ws ::= [ \t\n]*
 ################################################
 
 symbol1-item ::= string ws
-root ::= "[" ws symbol1-item* ws "]" ws
+root ::= "[" ws (symbol1-item ("," ws symbol1-item)*)? "]" ws
 
 ###############################
 # Primitive value type symbols
@@ -1528,7 +1528,7 @@ symbol10-type-value ::= "\"openai\""
 symbol-9-oneof-1 ::= "{" ws "\"type\"" ws ":" ws symbol10-type-value "}" ws
 symbol5-currentAIModel-value ::= symbol-6-oneof-0 | symbol-9-oneof-1
 symbol12-item ::= string ws
-symbol11-favoriteColors-value ::= "[" ws symbol12-item* ws "]" ws
+symbol11-favoriteColors-value ::= "[" ws (symbol12-item ("," ws symbol12-item)*)? "]" ws
 root ::= "{" ws "\"name\"" ws ":" ws symbol1-name-value "," ws "\"age\"" ws ":" ws symbol2-age-value "," ws "\"usesAI\"" ws ":" ws symbol3-usesAI-value "," ws "\"favoriteAnimal\"" ws ":" ws symbol4-favoriteAnimal-value "," ws "\"currentAIModel\"" ws ":" ws symbol5-currentAIModel-value "," ws "\"favoriteColors\"" ws ":" ws symbol11-favoriteColors-value "}" ws
 
 ###############################

--- a/gbnf/src/json.rs
+++ b/gbnf/src/json.rs
@@ -469,20 +469,44 @@ fn create_array_grammar_items(
                 items: rhs_start
                     .iter()
                     .chain(
-                        [
-                            ProductionItem::NonTerminal(
-                                NonTerminalSymbol {
-                                    name: item_template_name.clone(),
-                                },
-                                RepetitionType::ZeroOrMore,
-                            ),
-                            ProductionItem::NonTerminal(
-                                NonTerminalSymbol {
-                                    name: "ws".to_string(),
-                                },
-                                RepetitionType::One,
-                            ),
-                        ]
+                        [ProductionItem::Group(
+                            Box::new(Production {
+                                items: vec![
+                                    ProductionItem::NonTerminal(
+                                        NonTerminalSymbol {
+                                            name: item_template_name.clone(),
+                                        },
+                                        RepetitionType::One,
+                                    ),
+                                    ProductionItem::Group(
+                                        Box::new(Production {
+                                            items: vec![
+                                                ProductionItem::Terminal(
+                                                    TerminalSymbol {
+                                                        value: ",".to_string(),
+                                                    },
+                                                    RepetitionType::One,
+                                                ),
+                                                ProductionItem::NonTerminal(
+                                                    NonTerminalSymbol {
+                                                        name: "ws".to_string(),
+                                                    },
+                                                    RepetitionType::One,
+                                                ),
+                                                ProductionItem::NonTerminal(
+                                                    NonTerminalSymbol {
+                                                        name: item_template_name.clone(),
+                                                    },
+                                                    RepetitionType::One,
+                                                ),
+                                            ],
+                                        }),
+                                        RepetitionType::ZeroOrMore,
+                                    ),
+                                ],
+                            }),
+                            RepetitionType::ZeroOrOne,
+                        )]
                         .iter(),
                     )
                     .chain(rhs_end.iter())

--- a/gbnf/src/lib.rs
+++ b/gbnf/src/lib.rs
@@ -271,7 +271,9 @@ impl Grammar {
         let json = serde_json::from_str::<serde_json::Value>(schema)?;
         Grammar::from_json_schema_value(&json)
     }
-    pub fn from_json_schema_value(schema: &serde_json::Value) -> Result<Grammar, JsonSchemaParseError> {
+    pub fn from_json_schema_value(
+        schema: &serde_json::Value,
+    ) -> Result<Grammar, JsonSchemaParseError> {
         let mut g = Grammar::default();
 
         // add $id, $schema, title as commments at top of file
@@ -2234,5 +2236,4 @@ mod tests {
             "root ::= object\nvalue ::= object | array | string | number | (\"true\" | \"false\" | \"null\") ws\nobject ::= \"{\" ws (string \":\" ws value (\",\" ws string \":\" ws value)*)? \"}\" ws\narray ::= \"[\" ws (value (\",\" ws value)*)? \"]\" ws\nstring ::= \"\\\"\" ([^\"\\\\] | \"\\\\\" ([\"\\\\/bfnrt] | \"u\" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* \"\\\"\" ws\nnumber ::= (\"-\"? ([0-9] | [1-9] [0-9]*)) (\".\" [0-9]+)? ([eE] [-+]? [0-9]+)? ws\n# Optional space: by convention, applied in this grammar after literal chars when allowed\nws ::= ([ \\t\\n] ws)?\n"
         );
     }
-
 }


### PR DESCRIPTION
This fixes a bug where the rule for a schema like
```json
{"type" : "array", "item" : "integer"}
````
becomes:
```
symbol2-name-value ::= "\"tool\""
symbol5-item ::= integer ws
symbol4-array-of-ints-value ::= "[" ws symbol5-item* ws "]" ws
symbol3-arguments-value ::= "{" ws "\"tool\"" ws ":" ws symbol4-array-of-ints-value "}" ws
symbol-1-oneof-0 ::= "{" ws "\"name\"" ws ":" ws symbol2-name-value "," ws "\"arguments\"" ws ":" ws symbol3-arguments-value "}" ws
root ::= symbol-1-oneof-0
```
As seen in symbol4 this allows for the generation of arrays which look like `[1 2 3]` which is not valid json. This can result in models producing very wrong inputs for tools.